### PR TITLE
Fixed incorrect precedence when parsing arguments to invocations

### DIFF
--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -308,7 +308,7 @@ static Node* parsePrecedence(Parser* parser, Precedence precedence, ParseError**
 
     Node* left = rule->prefixFn(parser, &prefixToken, outErr);
 
-    while (precedence <= GET_RULE((*parser->current)->type)->precedence) {
+    while (precedence < GET_RULE((*parser->current)->type)->precedence) {
         Token* infixToken = *parser->current;
         advance(parser); // See comment above for prefix token
         rule = GET_RULE(infixToken->type);
@@ -394,7 +394,7 @@ static Node* parseInvocation(Parser* parser, Token** lParenToken, Node** targetE
         }
         listAdd(argNames, (void**) &argName);
 
-        Node* elem = parsePrecedence(parser, PREC_CALL, outErr);
+        Node* elem = parsePrecedence(parser, PREC_NONE, outErr);
         listAdd(args, (void**) &elem);
         if (PEEK(parser)->type == TOKEN_COMMA)
             advance(parser); // Consume the ","

--- a/test/parser/invocation_tests.c
+++ b/test/parser/invocation_tests.c
@@ -46,6 +46,31 @@ TEST(testInvocationExpression_2ArgsUnnamed, {
     ASSERT_EQ_STR("", invocation->argNames[1], "The second arg name should be empty");
 })
 
+TEST(testInvocationExpression_nestedExpr, {
+    Parser p = parseString("a(1 + 2)");
+
+    List* errorList = newList();
+    List* nodes = parse(&p, &errorList);
+    ASSERT_EQ(1, nodes->count, "There should be 1 element in the list");
+
+    Node* n = nodes->values[0];
+    ASSERT_EQ_STR("NODE_TYPE_INVOCATION", astNodeTypes[n->type], "The node should have type NODE_TYPE_INVOCATION");
+    InvocationNode* invocation = n->as.invocationNode;
+
+    ASSERT_TRUE(invocation->numArgs == 1, "There should be 1 argument to this invocation");
+    TestResult res = assertIdentNode(testName, invocation->target, "a");
+    if (!res.pass) return res;
+
+    Node* arg = invocation->arguments[0];
+    ASSERT_EQ_STR("NODE_TYPE_BINARY", astNodeTypes[arg->type], "The first arg should have type NODE_TYPE_BINARY");
+    BinaryNode* binary = arg->as.binaryNode;
+
+    res = assertLiteralNode(testName, binary->lExpr, LITERAL_NODE_INT, 1);
+    if (!res.pass) return res;
+
+    return assertLiteralNode(testName, binary->rExpr, LITERAL_NODE_INT, 2);
+})
+
 TEST(testInvocationExpression_nestedInvocations, {
     Parser p = parseString("a(b(\"b\"), \"a\")");
 
@@ -137,6 +162,7 @@ TEST(testInvocationExpression_namedAndUnnamed, {
 void runInvocationTests(Tester* tester) {
     tester->run(testInvocationExpression_noArgs);
     tester->run(testInvocationExpression_2ArgsUnnamed);
+    tester->run(testInvocationExpression_nestedExpr);
     tester->run(testInvocationExpression_nestedInvocations);
     tester->run(testInvocationExpression_errorNoComma);
 


### PR DESCRIPTION
  - Previously, I was parsing arguments into sub-nodes which had a precedence lower than (or equal to, see next bullet point) PREC_CALL.  This had the effect of only allowing simple expressions as arguments (such as literals) and also nested invocation expressions (as was covered in a unit test). It did _not_, however, allow for a binary expression, or anything else. Changing the maximum allowable precendence when parsing arguments from PREC_CALL to PREC_NONE (aka, the lowest precedence) allows all nested subexpressions
  - Also, I was consuming tokens while parsing arguments while the precedence was less than _or equal to_ the given precedence (which had been PREC_CALL). The incorrectness of this was made apparent when trying to parse an invocation with a nested binary expression (e.g. `abc(1 + 2)`), since everything that does not explicitly have a precedence has PREC_NONE. So, it's been changed from a <= to a strict <